### PR TITLE
Handle the possible different exceptions when an application tries to establish a session but an error is thrown 

### DIFF
--- a/example/lib/src/features/ble_wifi_screen/bloc/ble_wifi_bloc.dart
+++ b/example/lib/src/features/ble_wifi_screen/bloc/ble_wifi_bloc.dart
@@ -47,6 +47,12 @@ class BleWifiBloc extends Bloc<BleWifiEvent, BleWifiState> {
           emit(BleWifiEstablishedConnectionFailedState());
         case EstablishSessionStatus.keymismatch:
           emit(BleWifiEstablishedConnectionKeyMismatch());
+        case EstablishSessionStatus.bufferlengtherror:
+        // TODO: Handle this case.
+        case EstablishSessionStatus.unexpectedstate:
+        // TODO: Handle this case.
+        case EstablishSessionStatus.unknownerror:
+        // TODO: Handle this case.
       }
     });
 

--- a/lib/src/esp_prov.dart
+++ b/lib/src/esp_prov.dart
@@ -45,7 +45,21 @@ class EspProv {
       return EstablishSessionStatus.disconnected;
     } catch (e) {
       if (await transport.checkConnect()) {
-        return EstablishSessionStatus.keymismatch;
+        // TODO: review how to handle the possible errors.
+        // TODO: confirm the possible errors with flutter_ble_lib_ios_15 and flutter_blue_plus
+        // * It is just a possible way to handle the errors.
+        // * The ideal would be to have some standardized response to catch the exceptions,
+        // * But it must be confirmed.
+        String errorMessage = e.toString();
+        if (errorMessage.contains('Unexpected state')) {
+          return EstablishSessionStatus.unexpectedstate;
+        } else if (errorMessage.contains('Key mismatch')) {
+          return EstablishSessionStatus.keymismatch;
+        } else if (errorMessage.contains('Empty response')) {
+          return EstablishSessionStatus.bufferlengtherror;
+        } else {
+          return EstablishSessionStatus.unknownerror;
+        }
       } else {
         debugPrint('-----------------------');
         debugPrint('EstablishSession Error:');

--- a/lib/src/esp_prov.dart
+++ b/lib/src/esp_prov.dart
@@ -15,6 +15,10 @@ enum EstablishSessionStatus {
   connected,
   disconnected,
   keymismatch,
+  // TODO: review this values in the PR
+  bufferlengtherror,
+  unexpectedstate,
+  unknownerror
 }
 
 class EspProv {


### PR DESCRIPTION
`EstablishSessionStatus.keymismatch` is always returned when the session can't be established, even if it isn't because a wrong proof of possession. It is reported in #11 and this PR tries to handle this situation.

- a9795961a7916c1e686aae4fbea05ee5a2ffa4a2 is just a proposal of the idea, not the definitive way to handle the errors.
- The ideal would be to have some standardized response to catch the exceptions, but it must be confirmed reviewing the response using one or another bluetooth packages in the `TransportBle`.

## Tasks

- [ ] Detect the possible errors when the device is connected but throws errors that mustn't match with the `keymismatch`.
- [ ] Confirm the possible errors with more than one package (e.g., `flutter_ble_lib_ios_15` and `flutter_blue_plus`).
- [ ] Agree the most descriptive values for the errors.

## Errors detected

All this errors currently returns `keymismatch`, the first one is the correct one, the rest of them must have their specific value.

### Incorrect proof of possession

Tested with `flutter_blue_plus`, not tested with the example of this package.

```
I/flutter (17973): │ ⚠️ [ESP PROV] => type 'Null' is not a subtype of type 'FutureOr<Uint8List>'
```

Must returns the `EstablishSessionStatus.keymismatch`.

### With correct proof of possession

Tested with `flutter_blue_plus`, not tested with the example of this package.

```
I/flutter (17509): │ ⚠️ [ESP PROV] => Exception: Unexpected state
```

What must be returned? An `EstablishSessionStatus.unexpectederror` as a generic error without more information?

### Wrong MTU/buffer length

```
I/flutter (21478): │ ⚠️ [ESP PROV] => Exception: Empty response
```

This exception also returns a `KeyMistmatch`. It happens when MTU is increased over 512. I am using `flutter_blue_plus` and `512` is the default MTU in the `connect()` method, although I think it isn't a specific issue of that package and it may happen with any other Bluetooth plugin.

It must be researched more. It may return something like `EstablishSessionStatus.wrongbufferlength` or `EstablishSessionStatus.mtuerror`.

## Alternative idea

Thinking about the complexity of catching this errors, as mentioned in the second point of the introduction of this PR, an alternative may be to return a generic error that the user must catch according to the bluetooth package used in the `TransportBle`.