### PR TITLE
Fix: Correct offset handling in sendReceiveCustomData and set packageSize to 253

### DIFF
--- a/lib/src/esp_prov.dart
+++ b/lib/src/esp_prov.dart
@@ -227,12 +227,14 @@ class EspProv {
   }
 
   Future<Uint8List> sendReceiveCustomData(Uint8List data,
-      {int packageSize = 256}) async {
-    var i = data.length;
+      {int packageSize = 253}) async {
+    var remainingData = data.length;
     var offset = 0;
     List<int> ret = [];
-    while (i > 0) {
-      var needToSend = data.sublist(offset, i < packageSize ? i : packageSize);
+
+    while (remainingData > 0) {
+      int end = (remainingData < packageSize) ? remainingData : packageSize;
+      var needToSend = data.sublist(offset, offset + end);
       var encrypted = await security.encrypt(needToSend);
       var newData = await transport.sendReceive('custom-data', encrypted);
 
@@ -240,7 +242,9 @@ class EspProv {
         var decrypted = await security.decrypt(newData);
         ret += List.from(decrypted);
       }
-      i -= packageSize;
+
+      offset += end;
+      remainingData -= end;
     }
     return Uint8List.fromList(ret);
   }


### PR DESCRIPTION
Fixes #16

This PR addresses an issue in the sendReceiveCustomData function where data is repeatedly sent from offset 0 due to a missing update to the offset variable. The function now increments the offset by the chunk size in each iteration to ensure that data transmission progresses as intended.

Additionally, the packageSize has been set to 253 to ensure compatibility with iOS BLE limitations.

**Fix Details:**
- Updated sendReceiveCustomData to increment offset after each data chunk.
- Set packageSize to 253 to avoid iOS BLE packet size errors.